### PR TITLE
Add snapshot tests using cargo-insta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +193,7 @@ name = "file-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "insta",
  "ratatui",
  "rexpect",
  "tempfile",
@@ -232,6 +251,17 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+]
 
 [[package]]
 name = "instability"
@@ -538,6 +568,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = "1.0.98"
 ratatui = { version = "0.29.0", features = ["crossterm"] }
 
 [dev-dependencies]
+insta = "1.43.1"
 rexpect = "0.6.2"
 tempfile = "3.20.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,3 +150,20 @@ fn ui(f: &mut Frame, app: &App) {
     let cursor_x = area.x + app.cursor_x as u16;
     f.set_cursor(cursor_x, cursor_y);
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+    use insta::assert_display_snapshot;
+
+    #[test]
+    fn initial_ui_snapshot() {
+        let content = "hello\nworld".to_string();
+        let app = App::new(content);
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_display_snapshot!(terminal.backend());
+    }
+}
+

--- a/src/snapshots/file_viewer__tests__initial_ui_snapshot.snap
+++ b/src/snapshots/file_viewer__tests__initial_ui_snapshot.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"hello               "
+"world               "
+"                    "
+"                    "
+"                    "


### PR DESCRIPTION
## Summary
- add `insta` dev dependency
- implement a snapshot test for the initial UI
- include generated snapshot file

## Testing
- `cargo insta test --accept`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68680e3ad48c8330bbabc3ef1af84cdf