### PR TITLE
Add justfile with build/test/lint recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+# See https://github.com/casey/just for details
+
+# Default recipe
+default: build
+
+# Build the project
+build:
+    cargo build
+
+# Run the test suite
+# Equivalent to `cargo test`
+test:
+    cargo test
+
+# Run clippy lints and fail on warnings
+lint:
+    cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- add `justfile` so common commands can be run consistently

## Testing
- `cargo test --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: use of deprecated method `Frame::set_cursor`)*

------
https://chatgpt.com/codex/tasks/task_e_6869319c690c8330a1acd8f4dbe45ec2