### PR TITLE
Add clap CLI parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -131,6 +132,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 ratatui = { version = "0.29.0", features = ["crossterm"] }
-clap = "4.5.40"
+clap = { version = "4.5.40", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1.43.1"


### PR DESCRIPTION
## Summary
- use `clap` derive to parse CLI arguments
- expose `--headless` flag and file path via clap

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686932c7207083308e67bf252dee3f00