### PR TITLE
Add simple ex mode

### DIFF
--- a/src/snapshots/file_viewer__tests__command_q_ui_snapshot.snap
+++ b/src/snapshots/file_viewer__tests__command_q_ui_snapshot.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"hello               "
+"world               "
+"                    "
+"                    "
+":q                  "


### PR DESCRIPTION
## Summary
- add optional command input state to the app
- draw bottom command line when in command mode
- enter command mode with `:` and accept `:q` to quit
- add snapshot test for ex mode `:q`

## Testing
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6869340aed8c833081d9ffe443ffaf00