### PR TITLE
Implement G and gg motions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,18 @@ impl App {
             self.cursor_x = len;
         }
     }
+
+    fn goto_first_line(&mut self) {
+        self.cursor_y = 0;
+        self.cursor_x = 0;
+    }
+
+    fn goto_last_line(&mut self) {
+        if !self.lines.is_empty() {
+            self.cursor_y = self.lines.len() - 1;
+            self.cursor_x = 0;
+        }
+    }
 }
 
 #[derive(Parser)]
@@ -319,11 +331,21 @@ fn main() -> Result<()> {
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, content: String) -> io::Result<()> {
     let mut app = App::new(content);
+    let mut pending_g = false;
     loop {
         terminal.draw(|f| ui(f, &app))?;
 
         if let Event::Key(key) = event::read()? {
             let height = terminal.size()?.height;
+            if pending_g {
+                if let KeyCode::Char('g') = key.code {
+                    app.goto_first_line();
+                    app.ensure_visible(height);
+                    pending_g = false;
+                    continue;
+                }
+                pending_g = false;
+            }
             match key.code {
                 KeyCode::Char('q') => return Ok(()),
                 KeyCode::Char('h') => app.move_left(),
@@ -362,6 +384,13 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, content: String) -> io::Resul
                 }
                 KeyCode::Char('L') => {
                     app.cursor_bottom(height);
+                    app.ensure_visible(height);
+                }
+                KeyCode::Char('g') => {
+                    pending_g = true;
+                }
+                KeyCode::Char('G') => {
+                    app.goto_last_line();
                     app.ensure_visible(height);
                 }
                 _ => {}


### PR DESCRIPTION
## Summary
- add methods for jumping to the first and last lines
- support `G` to jump to the end of the file
- interpret `gg` as jump to the top of the file

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68693dd898008330833e40eec8a82516