### PR TITLE
Add scrolling snapshot tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -424,4 +424,30 @@ mod tests {
         terminal.draw(|f| ui(f, &app)).unwrap();
         assert_snapshot!(terminal.backend());
     }
+
+    #[test]
+    fn scrolling_ctrl_d_and_ctrl_u() {
+        // Build content with many lines so we can scroll
+        let content: String = (1..=20)
+            .map(|i| format!("line {i}\n"))
+            .collect();
+        let mut app = App::new(content);
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let height = terminal.size().unwrap().height;
+
+        // Scroll down using Ctrl-D three times to move the viewport
+        for _ in 0..3 {
+            app.half_page_down(height);
+        }
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("after_ctrl_d", terminal.backend());
+
+        // Scroll back up using Ctrl-U three times
+        for _ in 0..3 {
+            app.half_page_up(height);
+        }
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("after_ctrl_u", terminal.backend());
+    }
 }

--- a/src/snapshots/file_viewer__tests__after_ctrl_d.snap
+++ b/src/snapshots/file_viewer__tests__after_ctrl_d.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"line 3              "
+"line 4              "
+"line 5              "
+"line 6              "
+"line 7              "

--- a/src/snapshots/file_viewer__tests__after_ctrl_u.snap
+++ b/src/snapshots/file_viewer__tests__after_ctrl_u.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"line 1              "
+"line 2              "
+"line 3              "
+"line 4              "
+"line 5              "


### PR DESCRIPTION
## Summary
- add new snapshot tests for viewport scrolling
- verify that ctrl-D and ctrl-U move the screen correctly

## Testing
- `INSTA_UPDATE=always cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869632eaa108330aea49346dda08e2f