### PR TITLE
Handle exiting ex mode with ctrl+c

### DIFF
--- a/src/snapshots/file_viewer__tests__after_ctrl_d.snap
+++ b/src/snapshots/file_viewer__tests__after_ctrl_d.snap
@@ -6,4 +6,4 @@ expression: terminal.backend()
 "line 4              "
 "line 5              "
 "line 6              "
-"line 7              "
+"                    "

--- a/src/snapshots/file_viewer__tests__after_ctrl_u.snap
+++ b/src/snapshots/file_viewer__tests__after_ctrl_u.snap
@@ -6,4 +6,4 @@ expression: terminal.backend()
 "line 2              "
 "line 3              "
 "line 4              "
-"line 5              "
+"                    "


### PR DESCRIPTION
## Summary
- exit ex mode when pressing ctrl+c
- always reserve a bottom line for ex mode
- update snapshots for scrolling tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68698cc96cac833081531bb456ff4125