### PR TITLE
Fix viewport height to exclude command line

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -343,7 +343,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, content: String) -> io::Resul
         terminal.draw(|f| ui(f, &app))?;
 
         if let Event::Key(key) = event::read()? {
-            let height = terminal.size()?.height;
+            let height = terminal.size()?.height.saturating_sub(1);
 
             match &mut app.mode {
                 Mode::Normal => {
@@ -494,7 +494,7 @@ mod tests {
         let mut app = App::new(content);
         let backend = TestBackend::new(20, 5);
         let mut terminal = Terminal::new(backend).unwrap();
-        let height = terminal.size().unwrap().height;
+        let height = terminal.size().unwrap().height.saturating_sub(1);
 
         // Scroll down using Ctrl-D three times to move the viewport
         for _ in 0..3 {

--- a/src/snapshots/file_viewer__tests__after_ctrl_d.snap
+++ b/src/snapshots/file_viewer__tests__after_ctrl_d.snap
@@ -2,8 +2,8 @@
 source: src/main.rs
 expression: terminal.backend()
 ---
-"line 3              "
 "line 4              "
 "line 5              "
 "line 6              "
+"line 7              "
 "                    "


### PR DESCRIPTION
## Summary
- avoid moving cursor into the bottom blank line by subtracting one line from the viewport height
- update snapshot for the scrolling test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686990c4178083309f942d2e64795245