### PR TITLE
Refactor key handling into separate modules

### DIFF
--- a/src/keymaps/command.rs
+++ b/src/keymaps/command.rs
@@ -1,0 +1,26 @@
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::{App, Mode};
+
+pub fn handle(app: &mut App, cmd: &mut String, key: KeyEvent, _height: u16) -> bool {
+    match key.code {
+        KeyCode::Esc => app.mode = Mode::Normal,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.mode = Mode::Normal;
+        }
+        KeyCode::Enter => {
+            if cmd.trim() == "q" {
+                return true;
+            }
+            app.mode = Mode::Normal;
+        }
+        KeyCode::Backspace => {
+            cmd.pop();
+        }
+        KeyCode::Char(c) => {
+            cmd.push(c);
+        }
+        _ => {}
+    }
+    false
+}

--- a/src/keymaps/mod.rs
+++ b/src/keymaps/mod.rs
@@ -1,0 +1,3 @@
+pub mod command;
+pub mod normal;
+pub mod search;

--- a/src/keymaps/normal.rs
+++ b/src/keymaps/normal.rs
@@ -1,0 +1,75 @@
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::{App, Mode};
+
+pub fn handle(app: &mut App, key: KeyEvent, height: u16, pending_g: &mut bool) -> bool {
+    if key.code != KeyCode::Char('g') {
+        *pending_g = false;
+    }
+    match key.code {
+        KeyCode::Char('g') => {
+            if *pending_g {
+                app.goto_first_line();
+                app.ensure_visible(height);
+                *pending_g = false;
+            } else {
+                *pending_g = true;
+            }
+        }
+        KeyCode::Char('G') => {
+            app.goto_last_line();
+            app.ensure_visible(height);
+            *pending_g = false;
+        }
+        KeyCode::Char('/') => {
+            app.mode = Mode::Search(String::new());
+            *pending_g = false;
+        }
+        KeyCode::Char('n') => app.next_hit(height),
+        KeyCode::Char('N') => app.prev_hit(height),
+        KeyCode::Char(':') => app.mode = Mode::Command(String::new()),
+        KeyCode::Char('q') => return true,
+        KeyCode::Char('h') => app.move_left(),
+        KeyCode::Char('j') => app.move_down(height),
+        KeyCode::Char('k') => app.move_up(),
+        KeyCode::Char('l') => app.move_right(),
+        KeyCode::Char('w') => {
+            app.move_word_forward();
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('b') => {
+            app.move_word_backward();
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('{') => {
+            app.move_paragraph_up();
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('}') => {
+            app.move_paragraph_down();
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.half_page_up(height);
+        }
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.half_page_down(height);
+        }
+        KeyCode::Char('H') => {
+            app.cursor_top();
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('M') => {
+            app.cursor_middle(height);
+            app.ensure_visible(height);
+        }
+        KeyCode::Char('L') => {
+            app.cursor_bottom(height);
+            app.ensure_visible(height);
+        }
+        _ => {
+            *pending_g = false;
+        }
+    }
+    false
+}

--- a/src/keymaps/search.rs
+++ b/src/keymaps/search.rs
@@ -1,0 +1,27 @@
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::{App, Mode};
+
+pub fn handle(app: &mut App, query: &mut String, key: KeyEvent, height: u16) -> bool {
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.clear_search();
+            app.mode = Mode::Normal;
+        }
+        KeyCode::Esc => app.mode = Mode::Normal,
+        KeyCode::Enter => {
+            let q = query.clone();
+            app.set_search_query(q);
+            app.mode = Mode::Normal;
+            app.ensure_visible(height);
+        }
+        KeyCode::Backspace => {
+            query.pop();
+        }
+        KeyCode::Char(c) => {
+            query.push(c);
+        }
+        _ => {}
+    }
+    false
+}


### PR DESCRIPTION
## Summary
- refactor the large match on `app.mode` into separate key handling modules
- add `keymaps` module with a file per mode

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869a1a75de083309671f7db43f2818a