### PR TITLE
Add visual line mode

### DIFF
--- a/src/keymaps/mod.rs
+++ b/src/keymaps/mod.rs
@@ -1,3 +1,4 @@
 pub mod command;
 pub mod normal;
 pub mod search;
+pub mod visual;

--- a/src/keymaps/visual.rs
+++ b/src/keymaps/visual.rs
@@ -2,39 +2,13 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{App, Mode};
 
-pub fn handle(app: &mut App, key: KeyEvent, height: u16, pending_g: &mut bool) -> bool {
-    if key.code != KeyCode::Char('g') {
-        *pending_g = false;
-    }
+pub fn handle(app: &mut App, key: KeyEvent, height: u16) -> bool {
     match key.code {
-        KeyCode::Char('v') => {
-            app.mode = Mode::Visual;
-            app.selection_start = Some((app.cursor_y, app.cursor_x));
-            *pending_g = false;
-        }
-        KeyCode::Char('V') => {
-            app.mode = Mode::VisualLine;
-            app.selection_start = Some((app.cursor_y, 0));
-            app.cursor_x = 0;
-            *pending_g = false;
-        }
-        KeyCode::Char('g') => {
-            if *pending_g {
-                app.goto_first_line();
-                app.ensure_visible(height);
-                *pending_g = false;
-            } else {
-                *pending_g = true;
-            }
-        }
-        KeyCode::Char('G') => {
-            app.goto_last_line();
-            app.ensure_visible(height);
-            *pending_g = false;
-        }
-        KeyCode::Char('/') => {
-            app.mode = Mode::Search(String::new());
-            *pending_g = false;
+        KeyCode::Esc | KeyCode::Char('v') | KeyCode::Char('V') | KeyCode::Char('c')
+            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            app.mode = Mode::Normal;
+            app.selection_start = None;
         }
         KeyCode::Char('n') => app.next_hit(height),
         KeyCode::Char('N') => app.prev_hit(height),
@@ -78,9 +52,7 @@ pub fn handle(app: &mut App, key: KeyEvent, height: u16, pending_g: &mut bool) -
             app.cursor_bottom(height);
             app.ensure_visible(height);
         }
-        _ => {
-            *pending_g = false;
-        }
+        _ => {}
     }
     false
 }


### PR DESCRIPTION
## Summary
- add `VisualLine` mode variant
- support starting visual and visual line selection from normal mode
- implement `visual` keymap handler for both visual modes
- highlight entire lines when using visual line mode

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869a44d8fec8330ba7f53c167bf96a6