### PR TITLE
Add help screen

### DIFF
--- a/src/keymaps/command.rs
+++ b/src/keymaps/command.rs
@@ -9,10 +9,11 @@ pub fn handle(app: &mut App, cmd: &mut String, key: KeyEvent, _height: u16) -> b
             app.mode = Mode::Normal;
         }
         KeyCode::Enter => {
-            if cmd.trim() == "q" {
-                return true;
+            match cmd.trim() {
+                "q" => return true,
+                "h" | "help" => app.mode = Mode::Help,
+                _ => app.mode = Mode::Normal,
             }
-            app.mode = Mode::Normal;
         }
         KeyCode::Backspace => {
             cmd.pop();

--- a/src/snapshots/file_viewer__tests__help_screen.snap
+++ b/src/snapshots/file_viewer__tests__help_screen.snap
@@ -1,0 +1,10 @@
+---
+source: src/main.rs
+assertion_line: 706
+expression: terminal.backend()
+---
+"       q: quit      "
+"       ?: help      "
+"    h/j/k/l: move   "
+"   g/G: top/bottom  "
+"      /: search     "


### PR DESCRIPTION
## Summary
- add new `Help` mode and help text
- handle `?` shortcut and `help` command
- render help screen when active
- test help screen rendering

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869a3d2f54483308a2ccb6155b2d570