### PR TITLE
Add visual line mode

### DIFF
--- a/src/keymaps/normal.rs
+++ b/src/keymaps/normal.rs
@@ -12,6 +12,11 @@ pub fn handle(app: &mut App, key: KeyEvent, height: u16, pending_g: &mut bool) -
             app.selection_start = Some((app.cursor_y, app.cursor_x));
             *pending_g = false;
         }
+        KeyCode::Char('V') => {
+            app.mode = Mode::VisualLine;
+            app.selection_start = Some((app.cursor_y, app.cursor_x));
+            *pending_g = false;
+        }
         KeyCode::Char('g') => {
             if *pending_g {
                 app.goto_first_line();


### PR DESCRIPTION
## Summary
- support Visual Line selection mode
- use visual key handling for Visual Line mode
- highlight entire lines when in Visual Line mode

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6869a848e65883309ea2a70f52df37d0