### PR TITLE
Fix ':' and '/' mode switches

### DIFF
--- a/src/snapshots/file_viewer__tests__colon_enters_command_mode.snap
+++ b/src/snapshots/file_viewer__tests__colon_enters_command_mode.snap
@@ -1,0 +1,10 @@
+---
+source: src/main.rs
+assertion_line: 741
+expression: terminal.backend()
+---
+"hello               "
+"                    "
+"                    "
+"                    "
+":                   "

--- a/src/snapshots/file_viewer__tests__slash_enters_search_mode.snap
+++ b/src/snapshots/file_viewer__tests__slash_enters_search_mode.snap
@@ -1,0 +1,10 @@
+---
+source: src/main.rs
+assertion_line: 755
+expression: terminal.backend()
+---
+"hello               "
+"                    "
+"                    "
+"                    "
+"/                   "

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -33,7 +33,7 @@ fn test_interactive_command_q() -> anyhow::Result<()> {
 
     // Wait for app to render
     std::thread::sleep(std::time::Duration::from_millis(200));
-    p.send(":q")?; // send colon followed by q
+    p.send(":q\r")?; // send colon, q, and Enter
     p.flush()?;
     p.exp_eof()?;
 


### PR DESCRIPTION
## Summary
- correct mode handling logic by not overwriting changes
- send carriage return in pty test so :q exits properly
- add unit tests that trigger command and search mode via ':' and '/'

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a8c1e866c833089bc6b473318a572