### PR TITLE
Add verify command and AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+After making changes, Codex must run `just verify` from the repository root to build, test, format, and lint the project.

--- a/justfile
+++ b/justfile
@@ -12,6 +12,13 @@ build:
 test:
     cargo test
 
+# Format the code
+fmt:
+    cargo fmt --all -- --check
+
 # Run clippy lints and fail on warnings
 lint:
     cargo clippy --all-targets --all-features -- -D warnings
+
+# Run build, tests, formatting, and lint checks
+verify: build test fmt lint

--- a/src/main.rs
+++ b/src/main.rs
@@ -754,6 +754,7 @@ mod tests {
         terminal.draw(|f| ui(f, &app)).unwrap();
         assert_snapshot!("slash_enters_search_mode", terminal.backend());
     }
+    #[test]
     fn help_screen_renders() {
         let content = "hello".to_string();
         let mut app = App::new(content);


### PR DESCRIPTION
## Summary
- add `fmt` and `verify` recipes to `justfile`
- mark `help_screen_renders` test with `#[test]`
- add `AGENTS.md` with instructions to run `just verify`

## Testing
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686a8eae5d408330aba35c6327677089