### PR TITLE
Add search highlight & help command snapshot tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -681,7 +681,7 @@ fn ui(f: &mut Frame, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use insta::assert_snapshot;
+    use insta::{assert_snapshot, assert_debug_snapshot};
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend};
 
@@ -756,6 +756,32 @@ mod tests {
         keymaps::normal::handle(&mut app, key, height, &mut pending_g);
         terminal.draw(|f| ui(f, &app)).unwrap();
         assert_snapshot!("slash_enters_search_mode", terminal.backend());
+    }
+
+    #[test]
+    fn search_highlighting() {
+        let content = "find me here\nand here".to_string();
+        let mut app = App::new(content);
+        app.set_search_query("here".into());
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_debug_snapshot!("search_highlighting", terminal.backend().buffer());
+    }
+
+    #[test]
+    fn command_help_opens_help_screen() {
+        let content = "hello".to_string();
+        let mut app = App::new(content);
+        app.mode = Mode::Command("help".into());
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let height = terminal.size().unwrap().height.saturating_sub(1);
+        let mut cmd = "help".to_string();
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        keymaps::command::handle(&mut app, &mut cmd, key, height);
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("command_help_opens_help_screen", terminal.backend());
     }
     fn help_screen_renders() {
         let content = "hello".to_string();

--- a/src/snapshots/file_viewer__tests__command_help_opens_help_screen.snap
+++ b/src/snapshots/file_viewer__tests__command_help_opens_help_screen.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"File Viewer Help    "
+"                    "
+"?     Show this help"
+":help Open help     "
+"screen              "

--- a/src/snapshots/file_viewer__tests__search_highlighting.snap
+++ b/src/snapshots/file_viewer__tests__search_highlighting.snap
@@ -1,0 +1,21 @@
+---
+source: src/main.rs
+expression: terminal.backend().buffer()
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 20, height: 5 },
+    content: [
+        "find me here        ",
+        "and here            ",
+        "                    ",
+        "                    ",
+        "                    ",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 8, y: 0, fg: Reset, bg: Yellow, underline: Reset, modifier: NONE,
+        x: 12, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 4, y: 1, fg: Reset, bg: Yellow, underline: Reset, modifier: NONE,
+        x: 8, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}


### PR DESCRIPTION
## Summary
- add snapshot test for search highlighting
- add snapshot test to open help via `:help` command
- capture detailed buffer state for highlighting via `assert_debug_snapshot`

## Testing
- `INSTA_UPDATE=auto cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686adc0265188330b2ea2ac990b58273