### PR TITLE
Add visual mode status indicator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,14 @@ fn ui(f: &mut Frame, app: &App) {
             f.render_widget(paragraph, cmd_area);
             f.set_cursor_position((cmd_area.x + 1 + query.len() as u16, cmd_area.y));
         }
+        Mode::Visual => {
+            let paragraph = Paragraph::new("-- VISUAL --");
+            f.render_widget(paragraph, cmd_area);
+        }
+        Mode::VisualLine => {
+            let paragraph = Paragraph::new("-- VISUAL LINE --");
+            f.render_widget(paragraph, cmd_area);
+        }
         _ => {
             let blank = Paragraph::new("");
             f.render_widget(blank, cmd_area);
@@ -766,5 +774,27 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| ui(f, &app)).unwrap();
         assert_snapshot!("help_screen", terminal.backend());
+    }
+
+    #[test]
+    fn visual_mode_indicator() {
+        let content = "hello".to_string();
+        let mut app = App::new(content);
+        app.mode = Mode::Visual;
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("visual_mode_indicator", terminal.backend());
+    }
+
+    #[test]
+    fn visual_line_mode_indicator() {
+        let content = "hello".to_string();
+        let mut app = App::new(content);
+        app.mode = Mode::VisualLine;
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("visual_line_mode_indicator", terminal.backend());
     }
 }

--- a/src/snapshots/file_viewer__tests__visual_line_mode_indicator.snap
+++ b/src/snapshots/file_viewer__tests__visual_line_mode_indicator.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"hello               "
+"                    "
+"                    "
+"                    "
+"-- VISUAL LINE --   "

--- a/src/snapshots/file_viewer__tests__visual_mode_indicator.snap
+++ b/src/snapshots/file_viewer__tests__visual_mode_indicator.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"hello               "
+"                    "
+"                    "
+"                    "
+"-- VISUAL --        "


### PR DESCRIPTION
## Summary
- show `-- VISUAL --` and `-- VISUAL LINE --` on the command line area when in Visual and Visual Line modes
- add snapshot tests for both indicators

## Testing
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686adca181248330aeaf7b7d8fc1ce75