### PR TITLE
Run `just verify` and address formatting issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -689,7 +689,7 @@ fn ui(f: &mut Frame, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use insta::{assert_snapshot, assert_debug_snapshot};
+    use insta::{assert_debug_snapshot, assert_snapshot};
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend};
 


### PR DESCRIPTION
## Summary
- format code after installing `rustfmt`

## Testing
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686af231ebbc8330a8e9c4e3e267ef05