### PR TITLE
Refine help screen output

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -458,16 +458,57 @@ pub fn lookup_and_run(
     false
 }
 
+fn format_key(key: KeyEvent) -> String {
+    use KeyCode::*;
+    let mut parts = Vec::new();
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        parts.push("Ctrl".to_string());
+    }
+    if key.modifiers.contains(KeyModifiers::ALT) {
+        parts.push("Alt".to_string());
+    }
+    let code = match key.code {
+        Char(c) => c.to_string(),
+        Enter => "Enter".to_string(),
+        Esc => "Esc".to_string(),
+        Backspace => "Backspace".to_string(),
+        _ => format!("{:?}", key.code),
+    };
+    parts.push(code);
+    parts.join("-")
+}
+
 pub fn help_lines() -> Vec<String> {
     let mut lines = vec!["File Viewer Help".to_string(), String::new()];
-    for binding in NORMAL_BINDINGS
-        .iter()
-        .chain(VISUAL_BINDINGS)
-        .chain(COMMAND_BINDINGS)
-        .chain(SEARCH_BINDINGS)
-        .chain(HELP_BINDINGS)
-    {
-        lines.push(format!("{:?} - {}", binding.key.code, binding.help));
+
+    lines.push("Normal mode:".to_string());
+    for binding in NORMAL_BINDINGS {
+        lines.push(format!("{} - {}", format_key(binding.key), binding.help));
     }
+    lines.push(String::new());
+
+    lines.push("Visual mode:".to_string());
+    for binding in VISUAL_BINDINGS {
+        lines.push(format!("{} - {}", format_key(binding.key), binding.help));
+    }
+    lines.push(String::new());
+
+    lines.push("Command mode:".to_string());
+    for binding in COMMAND_BINDINGS {
+        lines.push(format!("{} - {}", format_key(binding.key), binding.help));
+    }
+    lines.push(String::new());
+
+    lines.push("Search mode:".to_string());
+    for binding in SEARCH_BINDINGS {
+        lines.push(format!("{} - {}", format_key(binding.key), binding.help));
+    }
+    lines.push(String::new());
+
+    lines.push("Help screen:".to_string());
+    for binding in HELP_BINDINGS {
+        lines.push(format!("{} - {}", format_key(binding.key), binding.help));
+    }
+
     lines
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,7 +779,7 @@ mod tests {
         let content = "hello".to_string();
         let mut app = App::new(content);
         app.mode = Mode::Command("help".into());
-        let backend = TestBackend::new(20, 5);
+        let backend = TestBackend::new(20, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         let height = terminal.size().unwrap().height.saturating_sub(1);
         let mut ctx = commands::Context {
@@ -797,7 +797,7 @@ mod tests {
         let content = "hello".to_string();
         let mut app = App::new(content);
         app.mode = Mode::Help;
-        let backend = TestBackend::new(20, 5);
+        let backend = TestBackend::new(20, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| ui(f, &app)).unwrap();
         assert_snapshot!("help_screen", terminal.backend());

--- a/src/snapshots/file_viewer__tests__command_help_opens_help_screen.snap
+++ b/src/snapshots/file_viewer__tests__command_help_opens_help_screen.snap
@@ -1,10 +1,24 @@
 ---
 source: src/main.rs
-assertion_line: 792
 expression: terminal.backend()
 ---
 "File Viewer Help    "
 "                    "
-"Char('v') - Start   "
-"visual mode         "
-"Char('V') - Start   "
+"Normal mode:        "
+"v - Start visual    "
+"mode                "
+"V - Start visual    "
+"line mode           "
+"g - gg goto first   "
+"line                "
+"? - Show this help  "
+"G - Goto last line  "
+"/ - Search          "
+"n - Next search hit "
+"N - Prev search hit "
+": - Command mode    "
+"q - Quit            "
+"h - Move left       "
+"j - Move down       "
+"k - Move up         "
+"l - Move right      "

--- a/src/snapshots/file_viewer__tests__help_screen.snap
+++ b/src/snapshots/file_viewer__tests__help_screen.snap
@@ -1,10 +1,24 @@
 ---
 source: src/main.rs
-assertion_line: 803
 expression: terminal.backend()
 ---
 "File Viewer Help    "
 "                    "
-"Char('v') - Start   "
-"visual mode         "
-"Char('V') - Start   "
+"Normal mode:        "
+"v - Start visual    "
+"mode                "
+"V - Start visual    "
+"line mode           "
+"g - gg goto first   "
+"line                "
+"? - Show this help  "
+"G - Goto last line  "
+"/ - Search          "
+"n - Next search hit "
+"N - Prev search hit "
+": - Command mode    "
+"q - Quit            "
+"h - Move left       "
+"j - Move down       "
+"k - Move up         "
+"l - Move right      "


### PR DESCRIPTION
## Summary
- improve formatting for the help screen
- organize help lines by mode and clean up key labels
- show more of the help screen in snapshot tests

## Testing
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686af5f608108330a1879a4a18f33109