### PR TITLE
Add PTCR-mini inline comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,9 @@ dependencies = [
  "clap",
  "insta",
  "notify",
+ "once_cell",
  "ratatui",
+ "regex",
  "rexpect",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ anyhow = "1.0.98"
 ratatui = { version = "0.29.0", features = ["crossterm"] }
 clap = { version = "4.5.40", features = ["derive"] }
 notify = "8.1.0"
+regex = "1.11.1"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 insta = "1.43.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,12 @@ use ratatui::{
 };
 mod commands;
 mod keymaps;
+mod ptcr;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
     fs::File,
     io::{self, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::mpsc,
     time::Duration,
 };
@@ -131,6 +132,35 @@ impl Document {
 struct OverlayItem {
     after_line: usize,
     content: Vec<String>,
+}
+
+fn overlays_from_records(
+    records: &[ptcr::Record],
+    path: &Path,
+    lines_len: usize,
+) -> Vec<OverlayItem> {
+    let mut items = Vec::new();
+    for rec in records {
+        if rec.path != path {
+            continue;
+        }
+        let after = match rec.span {
+            ptcr::Span::File => lines_len,
+            ptcr::Span::Line(l) => l,
+            ptcr::Span::Point { line, .. } => line,
+            ptcr::Span::LineRange { end, .. } => end,
+            ptcr::Span::ColumnRange { line, .. } => line,
+            ptcr::Span::MultiLine { end_line, .. } => end_line,
+        };
+        let idx = if after > 0 { after - 1 } else { 0 };
+        let content = rec.body.iter().map(|l| format!("| {}", l)).collect();
+        items.push(OverlayItem {
+            after_line: idx,
+            content,
+        });
+    }
+    items.sort_by_key(|o| o.after_line);
+    items
 }
 
 enum DisplayLine<'a> {
@@ -574,7 +604,13 @@ fn run_app<B: Backend>(
     path: PathBuf,
     content: String,
 ) -> io::Result<()> {
-    let mut app = App::new(path, content);
+    let mut app = App::new(path.clone(), content);
+    let review_path = PathBuf::from(format!("{}.review", path.to_string_lossy()));
+    if review_path.exists() {
+        if let Ok(records) = ptcr::read_file(&review_path) {
+            app.overlays = overlays_from_records(&records, &path, app.doc.lines.len());
+        }
+    }
     let (tx, rx) = mpsc::channel();
     let mut watcher: RecommendedWatcher = RecommendedWatcher::new(
         move |res| {
@@ -905,5 +941,21 @@ mod tests {
 
         assert_eq!(app.cursor_y, 1);
         assert!(app.scroll <= app.cursor_y as u16);
+    }
+
+    #[test]
+    fn overlays_render_inline() {
+        let content = "line1\nline2".to_string();
+        let mut app = App::new(PathBuf::from("file.txt"), content);
+        let record = ptcr::Record {
+            path: PathBuf::from("file.txt"),
+            span: ptcr::Span::Line(1),
+            body: vec!["note".to_string()],
+        };
+        app.overlays = overlays_from_records(&[record], &app.path, app.doc.lines.len());
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| ui(f, &app)).unwrap();
+        assert_snapshot!("overlay_render_inline", terminal.backend());
     }
 }

--- a/src/ptcr.rs
+++ b/src/ptcr.rs
@@ -1,0 +1,174 @@
+use anyhow::{Result, anyhow};
+use regex::Regex;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Span {
+    File,
+    Line(usize),
+    Point {
+        line: usize,
+        col: usize,
+    },
+    LineRange {
+        start: usize,
+        end: usize,
+    },
+    ColumnRange {
+        line: usize,
+        start_col: usize,
+        end_col: usize,
+    },
+    MultiLine {
+        start_line: usize,
+        start_col: usize,
+        end_line: usize,
+        end_col: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    pub path: PathBuf,
+    pub span: Span,
+    pub body: Vec<String>,
+}
+
+fn header_regex() -> &'static Regex {
+    static REGEX: once_cell::sync::Lazy<Regex> = once_cell::sync::Lazy::new(|| {
+        Regex::new(r"^([^\s:]+):(\*|(\d+)(?:\.(\d+))?(?:-(\d+)(?:\.(\d+))?)?)$").unwrap()
+    });
+    &REGEX
+}
+
+pub fn parse(input: &str) -> Result<Vec<Record>> {
+    let mut records = Vec::new();
+    let mut current: Option<Record> = None;
+
+    for line in input.lines() {
+        if let Some(caps) = header_regex().captures(line) {
+            if let Some(rec) = current.take() {
+                records.push(rec);
+            }
+            let path = caps.get(1).unwrap().as_str();
+            let span = if caps.get(3).is_none() {
+                Span::File
+            } else {
+                let start_line: usize = caps.get(3).unwrap().as_str().parse()?;
+                let start_col = caps.get(4).map(|m| m.as_str().parse::<usize>().unwrap());
+                match caps.get(5) {
+                    None => {
+                        if let Some(col) = start_col {
+                            Span::Point {
+                                line: start_line,
+                                col,
+                            }
+                        } else {
+                            Span::Line(start_line)
+                        }
+                    }
+                    Some(end_line_match) => {
+                        let end_line: usize = end_line_match.as_str().parse()?;
+                        let end_col = caps.get(6).map(|m| m.as_str().parse::<usize>().unwrap());
+                        match (start_col, end_col) {
+                            (None, None) => Span::LineRange {
+                                start: start_line,
+                                end: end_line,
+                            },
+                            (Some(sc), Some(ec)) => {
+                                if start_line == end_line {
+                                    Span::ColumnRange {
+                                        line: start_line,
+                                        start_col: sc,
+                                        end_col: ec,
+                                    }
+                                } else {
+                                    Span::MultiLine {
+                                        start_line,
+                                        start_col: sc,
+                                        end_line,
+                                        end_col: ec,
+                                    }
+                                }
+                            }
+                            _ => return Err(anyhow!("invalid span")),
+                        }
+                    }
+                }
+            };
+            current = Some(Record {
+                path: PathBuf::from(path),
+                span,
+                body: Vec::new(),
+            });
+        } else if let Some(rec) = current.as_mut() {
+            rec.body.push(line.to_string());
+        }
+    }
+    if let Some(rec) = current {
+        records.push(rec);
+    }
+    Ok(records)
+}
+
+#[allow(dead_code)]
+pub fn read_file(path: &Path) -> Result<Vec<Record>> {
+    let mut s = String::new();
+    File::open(path)?.read_to_string(&mut s)?;
+    parse(&s)
+}
+
+#[allow(dead_code)]
+fn span_to_string(span: &Span) -> String {
+    match span {
+        Span::File => "*".to_string(),
+        Span::Line(l) => format!("{}", l),
+        Span::Point { line, col } => format!("{}.{}", line, col),
+        Span::LineRange { start, end } => format!("{}-{}", start, end),
+        Span::ColumnRange {
+            line,
+            start_col,
+            end_col,
+        } => {
+            format!("{}.{}-{}.{}", line, start_col, line, end_col)
+        }
+        Span::MultiLine {
+            start_line,
+            start_col,
+            end_line,
+            end_col,
+        } => format!("{}.{}-{}.{}", start_line, start_col, end_line, end_col),
+    }
+}
+
+#[allow(dead_code)]
+pub fn write_file(path: &Path, records: &[Record]) -> Result<()> {
+    let mut f = File::create(path)?;
+    for (i, rec) in records.iter().enumerate() {
+        if i > 0 {
+            writeln!(f)?;
+        }
+        writeln!(f, "{}:{}", rec.path.display(), span_to_string(&rec.span))?;
+        for line in &rec.body {
+            writeln!(f, "{}", line)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_record() {
+        let input = "src/main.rs:1\nhello";
+        let recs = parse(input).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].path, PathBuf::from("src/main.rs"));
+        assert_eq!(recs[0].span, Span::Line(1));
+        assert_eq!(recs[0].body, vec!["hello".to_string()]);
+    }
+}

--- a/src/snapshots/file_viewer__tests__overlay_render_inline.snap
+++ b/src/snapshots/file_viewer__tests__overlay_render_inline.snap
@@ -1,0 +1,9 @@
+---
+source: src/main.rs
+expression: terminal.backend()
+---
+"line1               "
+"| note              "
+"line2               "
+"                    "
+"                    "

--- a/tests/ptcr.rs
+++ b/tests/ptcr.rs
@@ -1,0 +1,12 @@
+#[path = "../src/ptcr.rs"]
+mod ptcr;
+use std::path::PathBuf;
+
+#[test]
+fn parse_example() {
+    let input = "file.txt:1\nhello";
+    let recs = ptcr::parse(input).unwrap();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].path, PathBuf::from("file.txt"));
+    assert_eq!(recs[0].body, vec!["hello".to_string()]);
+}


### PR DESCRIPTION
## Summary
- implement basic PTCR-mini parser
- load `.review` files and convert records to overlays
- show overlay comments prefixed by `|`
- test PTCR parsing and overlay rendering

## Testing
- `INSTA_UPDATE=always cargo test`
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686affe9b93c8330938aaa7d5ec575df