### PR TITLE
Add CLI command definitions

### DIFF
--- a/src/command_spec.rs
+++ b/src/command_spec.rs
@@ -1,0 +1,27 @@
+use std::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommandSpec {
+    pub name: String,
+    pub template: String,
+}
+
+impl FromStr for CommandSpec {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err("expected <name>: <template>".into());
+        }
+        let name = parts[0].trim();
+        let template = parts[1].trim();
+        if name.is_empty() || template.is_empty() {
+            return Err("name or template empty".into());
+        }
+        Ok(CommandSpec {
+            name: name.to_string(),
+            template: template.to_string(),
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- add a `CommandSpec` module implementing `FromStr`
- parse `--command` CLI arguments into `CommandSpec`
- store command specs in `App`
- update tests for new `App::new` signature

## Testing
- `cargo check`
- `cargo test`
- `just verify`


------
https://chatgpt.com/codex/tasks/task_e_686b4639062483308105d43b0c4bc12d