### PR TITLE
Add custom command help and integration test

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use crate::command_spec::CommandSpec;
 use crate::{App, Mode};
 
 #[derive(Clone, Copy)]
@@ -514,7 +515,7 @@ fn format_key(key: KeyEvent) -> String {
     parts.join("-")
 }
 
-pub fn help_lines() -> Vec<String> {
+pub fn help_lines(commands: &[CommandSpec]) -> Vec<String> {
     let mut lines = vec!["File Viewer Help".to_string(), String::new()];
 
     lines.push("Normal mode:".to_string());
@@ -544,6 +545,14 @@ pub fn help_lines() -> Vec<String> {
     lines.push("Help screen:".to_string());
     for binding in HELP_BINDINGS {
         lines.push(format!("{} - {}", format_key(binding.key), binding.help));
+    }
+
+    if !commands.is_empty() {
+        lines.push(String::new());
+        lines.push("Custom commands:".to_string());
+        for cmd in commands {
+            lines.push(format!(":{} - {}", cmd.name, cmd.template));
+        }
     }
 
     lines

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,7 +701,8 @@ fn run_app<B: Backend>(
 fn ui(f: &mut Frame, app: &App) {
     let area = f.area();
     if matches!(app.mode, Mode::Help) {
-        let text = commands::help_lines().join("\n");
+        let cmds: Vec<CommandSpec> = app.commands.values().cloned().collect();
+        let text = commands::help_lines(&cmds).join("\n");
         let paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
         return;

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -1,5 +1,6 @@
 use rexpect::spawn;
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use tempfile::NamedTempFile;
 
 #[test]
@@ -36,6 +37,50 @@ fn test_interactive_command_q() -> anyhow::Result<()> {
     p.send(":q\r")?; // send colon, q, and Enter
     p.flush()?;
     p.exp_eof()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_custom_command_execution() -> anyhow::Result<()> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "hello world")?;
+
+    let out = NamedTempFile::new()?;
+
+    let mut script = NamedTempFile::new()?;
+    writeln!(script, "#!/bin/sh")?;
+    writeln!(script, "echo \"$@\" >> {}", out.path().display())?;
+    script.flush()?;
+    let script_path = script.into_temp_path();
+    let mut perms = std::fs::metadata(&script_path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms)?;
+
+    let cmd_spec = format!("foo:{} {{line}} {{col}} {{args}}", script_path.display());
+    eprintln!("cmd_spec={}", cmd_spec);
+
+    let mut p = spawn(
+        &format!(
+            "target/debug/file-viewer {} --command \"{}\"",
+            file.path().display(),
+            cmd_spec
+        ),
+        Some(5_000),
+    )?;
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    p.send(":foo test-arg\r")?;
+    p.flush()?;
+    // wait for command to run
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    p.send("q")?;
+    p.flush()?;
+    p.exp_eof()?;
+
+    let output = std::fs::read_to_string(out.path())?;
+    eprintln!("output read: {}", output.trim());
+    assert_eq!(output.trim(), "1 1 test-arg");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- show user-defined commands in help screen
- support dynamic help lines
- verify custom command execution via integration test

## Testing
- `just verify`

------
https://chatgpt.com/codex/tasks/task_e_686b4b32c18c8330806f833b783daf94